### PR TITLE
a better way to add to queue?

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -268,12 +268,10 @@ class Scheduler(object):
         # If job is a repeated job, decrement counter
         if repeat:
             job.meta['repeat'] = int(repeat) - 1
-        job.enqueued_at = datetime.utcnow()
-        job.save()
 
         queue = self.get_queue_for_job(job)
         self.connection.sadd(queue.redis_queues_keys, queue.key)
-        queue.push_job_id(job.id)
+        queue.enqueue_job(job)
         self.connection.zrem(self.scheduled_jobs_key, job.id)
 
         if interval:

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -270,7 +270,6 @@ class Scheduler(object):
             job.meta['repeat'] = int(repeat) - 1
 
         queue = self.get_queue_for_job(job)
-        self.connection.sadd(queue.redis_queues_keys, queue.key)
         queue.enqueue_job(job)
         self.connection.zrem(self.scheduled_jobs_key, job.id)
 


### PR DESCRIPTION
calling enqueue_job updates the job status also. 
the call also updates the `enqueued_at` key

I might be missing something over here. Let me know if I should checkout something else also.
